### PR TITLE
Add coveralls support for the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ script:
   - s/test
 after_success:
   - cd ${TRAVIS_BUILD_DIR}
-  - coveralls --build-root build --gcov-options '\-lp' -e spec -E CMakeFiles/feature_tests\. -E /CompilerIdC/ -E /CompilerIdCXX/
+  - coveralls --build-root build --gcov-options '\-lp' -e spec -E build/CMakeFiles/feature_tests.* -E .*/CompilerIdC/.* -E .*/CompilerIdCXX/.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ script:
   - s/test
 after_success:
   - cd ${TRAVIS_BUILD_DIR}
-  - coveralls --build-root build --gcov-options '\-lp' -e spec -E "build/CMakeFiles/feature_tests.*" -E ".*/CompilerIdC/.*" -E ".*/CompilerIdCXX/.*"
+  - coveralls --build-root build --gcov-options '\-lp' -e spec -E ".*build/CMakeFiles/feature_tests.*" -E ".*/CompilerIdC/.*" -E ".*/CompilerIdCXX/.*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ script:
   - s/build
   - s/test
 after_success:
+  - cd ${TRAVIS_BUILD_DIR}
   - coveralls --build-root build --gcov-options '\-lp' -e build -e spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ script:
   - s/test
 after_success:
   - cd ${TRAVIS_BUILD_DIR}
-  - coveralls --build-root build --gcov-options '\-lp' -e spec -e build/CMakeFiles -e build/CMakeFiles/feature_tests.c -e build/CMakeFiles/feature_tests.cxx -E build/CMakeFiles/\\d.*
+  - coveralls --build-root build --gcov-options '\-lp' -e spec -e build/CMakeFiles/feature_tests.c -e build/CMakeFiles/feature_tests.cxx -E build/CMakeFiles/\\d.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ script:
   - s/test
 after_success:
   - cd ${TRAVIS_BUILD_DIR}
-  - coveralls --build-root build --gcov-options '\-lp' -e spec -e build/CMakeFiles/feature_tests.c -e build/CMakeFiles/feature_tests.cxx -E build/CMakeFiles/\\d.*
+  - coveralls --build-root build --gcov-options '\-lp' -e spec -E CMakeFiles/feature_tests\. -E /CompilerIdC/ -E /CompilerIdCXX/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ script:
   - s/test
 after_success:
   - cd ${TRAVIS_BUILD_DIR}
-  - coveralls --build-root build --gcov-options '\-lp' -e build -e spec
+  - coveralls --build-root build --gcov-options '\-lp' -e spec -e build/CMakeFiles -e build/CMakeFiles/feature_tests.c -e build/CMakeFiles/feature_tests.cxx -E build/CMakeFiles/\\d.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,7 @@ os: osx
 osx_image: xcode10.1
 
 before_install:
-  - brew update
-  - eval "$(pyenv init -)"
-  - pyenv install 2.7.6
-  - pyenv global 2.7.6
-  - pyenv rehash
   - pip install cpp-coveralls
-  - pyenv rehash
 script:
   - s/setup -D FORENSICS_COVERAGE=ON
   - s/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ osx_image: xcode10.1
 
 before_install:
   - brew update
-  - brew upgrade pyenv
   - eval "$(pyenv init -)"
   - pyenv install 2.7.6
   - pyenv global 2.7.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,18 @@ sudo: false
 os: osx
 osx_image: xcode9.3
 
+before_install:
+  - brew update
+  - brew install pyenv
+  - eval "$(pyenv init -)"
+  - pyenv install 2.7.6
+  - pyenv global 2.7.6
+  - pyenv rehash
+  - pip install cpp-coveralls
+  - pyenv rehash
 script:
-  - s/setup
+  - s/setup -D FORENSICS_COVERAGE=ON
   - s/build
   - s/test
+after_success:
+  - coveralls --build-root build -gcov-options '\-lp' -e build -e spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: cpp
 sudo: false
 os: osx
-osx_image: xcode9.3
+osx_image: xcode10.1
 
 before_install:
   - brew update
-  - brew install pyenv
+  - brew upgrade pyenv
   - eval "$(pyenv init -)"
   - pyenv install 2.7.6
   - pyenv global 2.7.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ script:
   - s/build
   - s/test
 after_success:
-  - coveralls --build-root build -gcov-options '\-lp' -e build -e spec
+  - coveralls --build-root build --gcov-options '\-lp' -e build -e spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ script:
   - s/test
 after_success:
   - cd ${TRAVIS_BUILD_DIR}
-  - coveralls --build-root build --gcov-options '\-lp' -e spec -E build/CMakeFiles/feature_tests.* -E .*/CompilerIdC/.* -E .*/CompilerIdCXX/.*
+  - coveralls --build-root build --gcov-options '\-lp' -e spec -E "build/CMakeFiles/feature_tests.*" -E ".*/CompilerIdC/.*" -E ".*/CompilerIdCXX/.*"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.8)
 project(forensics LANGUAGES C CXX)
 
 option(FORENSICS_BUILD_TESTS "Build tests" OFF)
+option(FORENSICS_COVERAGE "Enable code coverage" OFF)
 
 # max out the warning settings for the compilers (why isn't there a generic way to do this?)
 if (MSVC)
@@ -41,6 +42,12 @@ target_compile_options(
   $<$<CXX_COMPILER_ID:AppleClang>:-Wall -Wextra -Wpedantic -Wno-unused-parameter>
   $<$<CXX_COMPILER_ID:MSVC>:/W4 /wd4100>
 )
+if (FORENSICS_COVERAGE)
+  target_compile_options(forensics PRIVATE $<$<CXX_COMPILER_ID:AppleClang>:--coverage>)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    set_target_properties(forensics PROPERTIES LINK_FLAGS --coverage)
+  endif()
+endif()
 
 # test app
 if (FORENSICS_BUILD_TESTS)
@@ -58,6 +65,12 @@ if (FORENSICS_BUILD_TESTS)
     $<$<CXX_COMPILER_ID:AppleClang>:-Wall -Wextra -Wpedantic -Wno-unused-parameter>
     $<$<CXX_COMPILER_ID:MSVC>:/W4 /wd4100>
   )
+  if (FORENSICS_COVERAGE)
+    target_compile_options(test_runner PRIVATE $<$<CXX_COMPILER_ID:AppleClang>:--coverage>)
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+      set_target_properties(test_runner PROPERTIES LINK_FLAGS --coverage)
+    endif()
+  endif()
 
   # test suite
   enable_testing()


### PR DESCRIPTION
Right now this is only for the OSX build on travis. Enable with `-D FORENSICS_COVERAGE=NO` to the `setup` script.